### PR TITLE
Remove npm requirement, update deps to latest

### DIFF
--- a/package.json
+++ b/package.json
@@ -5,12 +5,11 @@
   "main": "lib/src/index.js",
   "type": "lib/src/index.d.ts",
   "scripts": {
-    "build": "npm run lint && tsc",
     "clean": "rm -rf lib/",
     "lint": "eslint . --ext .ts --max-warnings=0",
     "test": "jest",
     "coverage": "jest --coverage",
-    "prepare": "npm run build"
+    "prepare": "tsc"
   },
   "repository": {
     "type": "git",
@@ -23,18 +22,19 @@
   },
   "homepage": "https://github.com/FiveOFive/ws-pubsub#readme",
   "devDependencies": {
-    "@types/jest": "^26.0.23",
-    "@types/node": "^14.0.23",
-    "@types/uuid": "^8.0.0",
-    "@types/ws": "^7.2.6",
-    "@typescript-eslint/eslint-plugin": "^3.6.1",
-    "@typescript-eslint/parser": "^3.6.1",
-    "eslint": "^7.5.0",
-    "jest": "^26.6.3",
-    "typescript": "^3.9.7"
+    "@types/jest": "^29.5.11",
+    "@types/node": "^16.0.0",
+    "@types/uuid": "^9.0.7",
+    "@types/ws": "^8.5.10",
+    "@typescript-eslint/eslint-plugin": "^6.19.0",
+    "@typescript-eslint/parser": "^6.19.0",
+    "eslint": "^8.56.0",
+    "jest": "^29.7.0",
+    "ts-jest": "^29.1.1",
+    "typescript": "^5.3.3"
   },
   "dependencies": {
-    "uuid": "^8.2.0",
-    "ws": "^7.3.1"
+    "uuid": "^9.0.1",
+    "ws": "^8.16.0"
   }
 }


### PR DESCRIPTION
- Simplifies build to work with other package managers
- Updates dev deps for latest
- Updates deps to latest.
    - UUID version bump drops Node 10/IE 11 support, shouldn't matter as it's used on backend
    - WS version bump drops Node 10, and makes validation and parsing stricter, and does not automatically close ws connections. See details here: https://github.com/websockets/ws/commits/8.0.0/ 

All tests pass.
